### PR TITLE
fix cayo difficulty detection

### DIFF
--- a/Cherax/Functions/Helper.lua
+++ b/Cherax/Functions/Helper.lua
@@ -49,7 +49,7 @@ end
 
 function Helper.SetCayoMaxPayout()
     local target     = eStat.MPX_H4CNF_TARGET:Get()
-    local difficulty = (eStat.MPX_H4_PROGRESS:Get() == eTable.Heist.CayoPerico.Difficulties[2].index) and 2 or 1
+    local difficulty = ((eStat.MPX_H4_PROGRESS:Get() & 4096) ~= 0) and 2 or 1
 
     local payouts = {
         [0] = { 630000,  693000  },


### PR DESCRIPTION
Fixes auto payout sometimes not detecting the correct difficulty
I currently have a heist set up on hard mode where the value is 131071
I got this bit mask from the game scripts